### PR TITLE
fix: application name 삭제

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,0 @@
-spring:
-  application:
-    name: global


### PR DESCRIPTION
application.yml의 application name으로 인해 global 라이브러리를 호출하는 서비스들의 이름이 유레카 서버에 global로 등록됨.
따라서 해당 부분의 코드를 삭제.